### PR TITLE
Restart node_exporter service on systemd unit or initscript change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,9 +15,16 @@
   when: prometheus_use_service|bool
 
 
+- name: restart node_exporter (systemd)
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: node_exporter
+  when: prometheus_node_exporter_use_systemd|bool
 
 - name: restart node_exporter
   service: name=node_exporter state=restarted
+  when: not prometheus_node_exporter_use_systemd|bool
 
 - name: reload node_exporter
   service: name=node_exporter state=reloaded

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -109,8 +109,16 @@
 
 - name: copy systemd config to server
   template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
+  register: prometheus_node_exporter_service_file
   when: prometheus_node_exporter_use_systemd|bool
 
 
 - name: set INIT status and start
   service: name=node_exporter enabled=yes state=started
+
+- name: restart node_exporter service if unit file changed
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: node_exporter
+  when: prometheus_node_exporter_use_systemd|bool and prometheus_node_exporter_service_file.changed

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -109,20 +109,15 @@
   template: src="../templates/node_exporter.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/node_exporter"  mode="a+x"
   when: not prometheus_node_exporter_use_systemd|bool
   register: initscriptcopy
+  notify: restart node_exporter
 
 - name: copy systemd config to server
   template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
   when: prometheus_node_exporter_use_systemd|bool
   register: unitfilecopy
+  notify: restart node_exporter (systemd)
 
 
 - name: set INIT status and start
   service: name=node_exporter enabled=yes state=started
   when: "{{ not initscriptcopy.skipped|default(False) or not unitfilecopy.skipped|default(False) }}"
-
-- name: restart node_exporter service if unit file changed
-  systemd:
-    state: restarted
-    daemon_reload: yes
-    name: node_exporter
-  when: prometheus_node_exporter_use_systemd|bool and unitfilecopy.changed


### PR DESCRIPTION
Extension to https://github.com/teralytics/ansible-prometheus/pull/2 with 2 changes:
* now restart works also for the 'non systemd' case
* the newer (systemd) restart logic was also moved to the hander